### PR TITLE
Add additional fields to message output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,21 @@ The SQL argument provides an optional feature that enables the use of a SQL data
 You'll have to create the database yourself so i've attached the schema below. 
 ```sql
 CREATE TABLE messages (
-    channel_id   BIGINT UNSIGNED NOT NULL,
-    channel_name VARCHAR(100)    NOT NULL DEFAULT '',
-    author_id    BIGINT UNSIGNED NOT NULL,
-    author_name  VARCHAR(64)     NOT NULL DEFAULT '',
-    message_id   BIGINT UNSIGNED NOT NULL,
-    message      TEXT            NOT NULL,
-    has_media    BOOLEAN         NOT NULL,
+    channel_id          BIGINT UNSIGNED  NOT NULL,
+    channel_name        VARCHAR(100)     NOT NULL DEFAULT '',
+    author_id           BIGINT UNSIGNED  NOT NULL,
+    author_name         VARCHAR(64)      NOT NULL DEFAULT '',
+    message_id          BIGINT UNSIGNED  NOT NULL,
+    message             TEXT             NOT NULL,
+    has_media           BOOLEAN          NOT NULL,
+    timestamp           VARCHAR(64)      NOT NULL DEFAULT '',
+    edited_timestamp    VARCHAR(64)      NULL,
+    reply_to_message_id BIGINT UNSIGNED  NULL,
+    message_type        TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    pinned              BOOLEAN          NOT NULL DEFAULT 0,
+    attachment_urls     TEXT             NULL,
+    embed_count         INT UNSIGNED     NOT NULL DEFAULT 0,
+    reactions           TEXT             NULL,
     PRIMARY KEY (message_id)
 );
 ```
@@ -62,7 +70,15 @@ CREATE TABLE messages (
 To migrate an existing table:
 ```sql
 ALTER TABLE messages
-    ADD COLUMN channel_name VARCHAR(100) NOT NULL DEFAULT '' AFTER channel_id,
-    ADD COLUMN author_name  VARCHAR(64)  NOT NULL DEFAULT '' AFTER author_id;
+    ADD COLUMN channel_name        VARCHAR(100)     NOT NULL DEFAULT '' AFTER channel_id,
+    ADD COLUMN author_name         VARCHAR(64)      NOT NULL DEFAULT '' AFTER author_id,
+    ADD COLUMN timestamp           VARCHAR(64)      NOT NULL DEFAULT '' AFTER has_media,
+    ADD COLUMN edited_timestamp    VARCHAR(64)      NULL                AFTER timestamp,
+    ADD COLUMN reply_to_message_id BIGINT UNSIGNED  NULL                AFTER edited_timestamp,
+    ADD COLUMN message_type        TINYINT UNSIGNED NOT NULL DEFAULT 0  AFTER reply_to_message_id,
+    ADD COLUMN pinned              BOOLEAN          NOT NULL DEFAULT 0  AFTER message_type,
+    ADD COLUMN attachment_urls     TEXT             NULL                AFTER pinned,
+    ADD COLUMN embed_count         INT UNSIGNED     NOT NULL DEFAULT 0  AFTER attachment_urls,
+    ADD COLUMN reactions           TEXT             NULL                AFTER embed_count;
 ```
 *Inspired by [DiscordChatExporter](https://github.com/Tyrrrz/DiscordChatExporter).*

--- a/README.md
+++ b/README.md
@@ -48,12 +48,21 @@ The SQL argument provides an optional feature that enables the use of a SQL data
 You'll have to create the database yourself so i've attached the schema below. 
 ```sql
 CREATE TABLE messages (
-    channel_id BIGINT UNSIGNED NOT NULL,
-    author_id BIGINT UNSIGNED NOT NULL,
-    message_id BIGINT UNSIGNED NOT NULL,
-    message TEXT NOT NULL,
-    has_media BOOLEAN NOT NULL,
+    channel_id   BIGINT UNSIGNED NOT NULL,
+    channel_name VARCHAR(100)    NOT NULL DEFAULT '',
+    author_id    BIGINT UNSIGNED NOT NULL,
+    author_name  VARCHAR(64)     NOT NULL DEFAULT '',
+    message_id   BIGINT UNSIGNED NOT NULL,
+    message      TEXT            NOT NULL,
+    has_media    BOOLEAN         NOT NULL,
     PRIMARY KEY (message_id)
 );
+```
+
+To migrate an existing table:
+```sql
+ALTER TABLE messages
+    ADD COLUMN channel_name VARCHAR(100) NOT NULL DEFAULT '' AFTER channel_id,
+    ADD COLUMN author_name  VARCHAR(64)  NOT NULL DEFAULT '' AFTER author_id;
 ```
 *Inspired by [DiscordChatExporter](https://github.com/Tyrrrz/DiscordChatExporter).*

--- a/src/discord_api/get_channel_messages.rs
+++ b/src/discord_api/get_channel_messages.rs
@@ -3,18 +3,35 @@ use reqwest::{Method, Response};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct Reaction {
+    pub emoji: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Message {
     pub channel_id: u64,
+    pub channel_name: String,
     pub author_id: u64,
+    pub author_name: String,
     pub message_id: u64,
     pub message: String,
     pub has_media: bool,
+    pub timestamp: String,
+    pub edited_timestamp: Option<String>,
+    pub reply_to_message_id: Option<u64>,
+    pub message_type: u8,
+    pub pinned: bool,
+    pub attachment_urls: Vec<String>,
+    pub embed_count: u32,
+    pub reactions: Vec<Reaction>,
 }
 
 impl DiscordApi {
     async fn process_messages(
         response: Response,
         channel_id: u64,
+        channel_name: String,
         wait_for_ratelimit: bool,
     ) -> Result<Vec<Message>, DiscordApiError> {
         if wait_for_ratelimit {
@@ -36,22 +53,94 @@ impl DiscordApi {
                     .and_then(|author| author.get("id"))
                     .and_then(|id| id.as_str())
                     .and_then(|id| id.parse::<u64>().ok());
+                let author_name = message_object
+                    .get("author")
+                    .and_then(|a| a.as_object())
+                    .and_then(|a| {
+                        a.get("global_name")
+                            .and_then(|n| n.as_str())
+                            .filter(|s| !s.is_empty())
+                            .or_else(|| a.get("username").and_then(|n| n.as_str()))
+                    })
+                    .unwrap_or("")
+                    .to_string();
                 let content = message_object
                     .get("content")
                     .and_then(|content| content.as_str())
                     .map(|s| s.to_string());
-                let has_media = !message_object
+                let attachment_urls: Vec<String> = message_object
                     .get("attachments")
                     .and_then(|att| att.as_array())
-                    .map(|arr| arr.is_empty())
-                    .unwrap_or(true);
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|a| a.get("url").and_then(|u| u.as_str()).map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let has_media = !attachment_urls.is_empty();
+                let timestamp = message_object
+                    .get("timestamp")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let edited_timestamp = message_object
+                    .get("edited_timestamp")
+                    .and_then(|t| t.as_str())
+                    .map(|s| s.to_string());
+                let reply_to_message_id = message_object
+                    .get("referenced_message")
+                    .and_then(|rm| rm.as_object())
+                    .and_then(|rm| rm.get("id"))
+                    .and_then(|id| id.as_str())
+                    .and_then(|id| id.parse::<u64>().ok());
+                let message_type = message_object
+                    .get("type")
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0) as u8;
+                let pinned = message_object
+                    .get("pinned")
+                    .and_then(|p| p.as_bool())
+                    .unwrap_or(false);
+                let embed_count = message_object
+                    .get("embeds")
+                    .and_then(|e| e.as_array())
+                    .map(|arr| arr.len() as u32)
+                    .unwrap_or(0);
+                let reactions: Vec<Reaction> = message_object
+                    .get("reactions")
+                    .and_then(|r| r.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|r| {
+                                let count = r.get("count").and_then(|c| c.as_u64()).unwrap_or(0);
+                                let emoji = r
+                                    .get("emoji")
+                                    .and_then(|e| e.as_object())
+                                    .and_then(|e| e.get("name").and_then(|n| n.as_str()))
+                                    .unwrap_or("")
+                                    .to_string();
+                                Reaction { emoji, count }
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
                 if let (Some(mid), Some(aid), Some(text)) = (message_id, author_id, content) {
                     messages_vec.push(Message {
                         channel_id,
+                        channel_name: channel_name.clone(),
                         author_id: aid,
+                        author_name,
                         message_id: mid,
                         message: text,
                         has_media,
+                        timestamp,
+                        edited_timestamp,
+                        reply_to_message_id,
+                        message_type,
+                        pinned,
+                        attachment_urls,
+                        embed_count,
+                        reactions,
                     });
                 }
             }
@@ -63,13 +152,14 @@ impl DiscordApi {
         &self,
         channel_id: u64,
         message_id: u64,
+        channel_name: String,
         wait_for_ratelimit: bool,
     ) -> Result<Vec<Message>, DiscordApiError> {
         let url = format!("channels/{}/messages?before={}&limit=100", channel_id, message_id);
         let response = self.request_with_relative_url_and_auth_header(Method::GET, &url).await?;
         let status = response.status().as_u16();
         match status {
-            200 => Self::process_messages(response, channel_id, wait_for_ratelimit).await,
+            200 => Self::process_messages(response, channel_id, channel_name, wait_for_ratelimit).await,
             _ => Err(DiscordApiError::UnexpectedResponseStatusCode(status, Some(response))),
         }
     }
@@ -77,13 +167,14 @@ impl DiscordApi {
     pub async fn get_channel_msgs(
         &self,
         channel_id: u64,
+        channel_name: String,
         wait_for_ratelimit: bool,
     ) -> Result<Vec<Message>, DiscordApiError> {
         let url = format!("channels/{}/messages?limit=100", channel_id);
         let response = self.request_with_relative_url_and_auth_header(Method::GET, &url).await?;
         let status = response.status().as_u16();
         match status {
-            200 => Self::process_messages(response, channel_id, wait_for_ratelimit).await,
+            200 => Self::process_messages(response, channel_id, channel_name, wait_for_ratelimit).await,
             _ => Err(DiscordApiError::UnexpectedResponseStatusCode(status, Some(response))),
         }
     }

--- a/src/scraper.rs
+++ b/src/scraper.rs
@@ -78,13 +78,14 @@ impl Scraper {
         &self,
         channel_id: u64,
         message_id: u64,
+        channel_name: String,
         use_personal: bool,
     ) -> Result<Vec<crate::discord_api::Message>, ScraperError> {
         let possible_messages = if message_id == 0 {
-            self.discord_api_client.get_channel_msgs(channel_id, use_personal).await
+            self.discord_api_client.get_channel_msgs(channel_id, channel_name.clone(), use_personal).await
         } else {
             self.discord_api_client
-                .get_channel_msgs_before_msg(channel_id, message_id, use_personal)
+                .get_channel_msgs_before_msg(channel_id, message_id, channel_name.clone(), use_personal)
                 .await
         };
         match possible_messages {
@@ -98,7 +99,7 @@ impl Scraper {
                         );
                         time::sleep(time::Duration::from_secs(SECONDS_TO_WAIT_IN_CASE_OF_HTTP_503 as u64))
                             .await;
-                        return self.scrape_msgs_before_msg(channel_id, message_id, use_personal).await;
+                        return self.scrape_msgs_before_msg(channel_id, message_id, channel_name, use_personal).await;
                     }
                     Err(ScraperError::DiscordApiError(
                         DiscordApiError::UnexpectedResponseStatusCode(status_code, response),
@@ -129,7 +130,7 @@ impl Scraper {
         let format_request = !channel_name.starts_with("dm_");
         loop {
             let messages = self
-                .scrape_msgs_before_msg(channel_id, last_message_id, format_request)
+                .scrape_msgs_before_msg(channel_id, last_message_id, channel_name.clone(), format_request)
                 .await?;
             if let Some(last_message) = messages.last() {
                 last_message_id = last_message.message_id;

--- a/src/utils/message_saver.rs
+++ b/src/utils/message_saver.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use color_eyre::eyre::Result;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::fs::{File, OpenOptions};
+use serde_json;
 
 pub enum SaveTarget {
     Jsonl,
@@ -57,14 +58,30 @@ impl SqlSaver {
 impl MessageSaver for SqlSaver {
     async fn save_messages(&mut self, messages: &[Message]) -> Result<()> {
         for message in messages {
+            let attachment_urls = serde_json::to_string(&message.attachment_urls).unwrap_or_default();
+            let reactions = serde_json::to_string(&message.reactions).unwrap_or_default();
             sqlx::query(
-                "INSERT INTO messages (channel_id, author_id, message_id, message, has_media) VALUES (?, ?, ?, ?, ?)"
+                "INSERT INTO messages \
+                 (channel_id, channel_name, author_id, author_name, message_id, message, has_media, \
+                  timestamp, edited_timestamp, reply_to_message_id, message_type, pinned, \
+                  attachment_urls, embed_count, reactions) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
             .bind(message.channel_id)
+            .bind(&message.channel_name)
             .bind(message.author_id)
+            .bind(&message.author_name)
             .bind(message.message_id)
             .bind(&message.message)
             .bind(message.has_media)
+            .bind(&message.timestamp)
+            .bind(&message.edited_timestamp)
+            .bind(message.reply_to_message_id)
+            .bind(message.message_type)
+            .bind(message.pinned)
+            .bind(attachment_urls)
+            .bind(message.embed_count)
+            .bind(reactions)
             .execute(&self.pool)
             .await?;
         }


### PR DESCRIPTION
- Adds `channel_name` and `author_name` fields to the `Message` struct, resolved from Discord API response data
- Adds rich metadata fields: `timestamp`, `edited_timestamp`, `reply_to_message_id`, `message_type`, `pinned`, `attachment_urls`, `embed_count`, and `reactions`
- Updates SQL schema and INSERT query to persist all new fields; includes migration SQL for existing tables in README